### PR TITLE
Update to use encoded_body for typhoeus

### DIFF
--- a/lib/api_auth/request_drivers/typhoeus.rb
+++ b/lib/api_auth/request_drivers/typhoeus.rb
@@ -18,7 +18,7 @@ module ApiAuth
       end
 
       def calculated_md5
-        md5_base64digest(@request.options[:body] || '')
+        md5_base64digest(@request.encoded_body || '')
       end
 
       def populate_content_md5


### PR DESCRIPTION
This PR is to use `request.encoded_body` for typhoeus instead of `request.options[:body]` to support post request with body params as a hash.
